### PR TITLE
Add optional channel parameter to enable beta builds with a _beta suffix to the channel.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,14 @@
 #!groovy
 
+properties([
+    parameters([
+        string(name: 'XPI_URL', defaultValue: 'https://addons.mozilla.org/firefox/downloads/latest-beta/8542/addon-8542-latest.xpi?src=dp-btn-devchannel'),
+        string(name: 'XPI_SIGN_CREDENTIALS', defaultValue: '41572f9c-06aa-46f0-9c3b-b7f4f78e9caa'),
+        string(name: 'XPI_SIGN_REPO_URL', defaultValue: 'git@github.com:cliqz/xpi-sign.git'),
+        string(name: 'CHANNEL', defaultValue: 'browser')
+    ])
+])
+
 node('master') {
     def imgName
 
@@ -36,7 +45,7 @@ node('master') {
             withEnv([
                 'RANDFILE=.rnd'
             ]) {
-                def addonId = sh(returnStdout: true, script: "/bin/bash ./repack_and_upload.sh $XPI_URL | grep 'Addon:' | head -n 1").trim()
+                def addonId = sh(returnStdout: true, script: "/bin/bash ./repack_and_upload.sh $XPI_URL $CHANNEL | grep 'Addon:' | head -n 1").trim()
                 currentBuild.description = addonId
             }
         }

--- a/repack_and_upload.sh
+++ b/repack_and_upload.sh
@@ -17,6 +17,12 @@ then
   exit 1
 fi
 
+# optional channel
+if [ $# -eq 2 ];
+then
+  CHANNEL=$2
+fi
+
 echo "CLIQZ: clobber"
 rm -rf $TMP_PATH
 mkdir $TMP_PATH
@@ -94,10 +100,18 @@ function webExtension {
   SIGNED_XPI_NAME=$ADDON_ID-$ADDON_VERSION-$CHANNEL-signed.xpi
   LATEST_XPI_NAME=latest.xpi
 
-  # put all the output files to a *_pre folder before going live
-  S3_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL"_pre"/$ADDON_ID/$SIGNED_XPI_NAME
-  LATEST_S3_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL"_pre"/$ADDON_ID/$LATEST_XPI_NAME
-  S3_UPDATE_JSON_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL"_pre"/$ADDON_ID/update.json
+  # for beta channels, we upload to _beta, otherwise upload to _pre
+  if [[ "$CHANNEL" == *_beta ]]
+  then
+    CHANNEL_DIR = $CHANNEL
+  else
+    # put all the output files to a *_pre folder before going live
+    CHANNEL_DIR = $CHANNEL"_pre"
+  fi
+
+  S3_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL_DIR/$ADDON_ID/$SIGNED_XPI_NAME
+  LATEST_S3_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL_DIR/$ADDON_ID/$LATEST_XPI_NAME
+  S3_UPDATE_JSON_UPLOAD_URL=s3://cdncliqz/update/$CHANNEL_DIR/$ADDON_ID/update.json
 
   # no _pre for emeded urls
   DOWNLOAD_URL=https://s3.amazonaws.com/cdncliqz/update/$CHANNEL/$ADDON_ID/$SIGNED_XPI_NAME


### PR DESCRIPTION
@chrmod This will enable the ghostery build to submit this job with `browser_beta` as the channel, which will then have a proper update channel.